### PR TITLE
Align work order and temper order forms

### DIFF
--- a/temper/temper_frame.py
+++ b/temper/temper_frame.py
@@ -1,5 +1,6 @@
 import customtkinter as ctk
 from tkinter import ttk, messagebox, Menu
+from tkcalendar import DateEntry
 from database import Database
 
 class TemperFrame(ctk.CTkFrame):
@@ -72,37 +73,63 @@ class TemperFrame(ctk.CTkFrame):
 
         win = ctk.CTkToplevel(self)
         win.title("Yeni Temper Siparişi")
-        win.geometry("500x350")
-        
-        ctk.CTkLabel(win, text="Firma (Cari):").grid(row=0, column=0, padx=10, pady=10, sticky="w")
+        win.geometry("500x450")
+
+        ctk.CTkLabel(win, text="Tarih:").grid(row=0, column=0, padx=10, pady=10, sticky="w")
+        self.temper_tarih_entry = DateEntry(win, date_pattern='y-mm-dd')
+        self.temper_tarih_entry.grid(row=0, column=1, padx=10, pady=10, sticky="ew")
+
+        ctk.CTkLabel(win, text="Firma (Cari):").grid(row=1, column=0, padx=10, pady=10, sticky="w")
         musteri_cerceve = ctk.CTkFrame(win, fg_color="transparent")
-        musteri_cerceve.grid(row=0, column=1, padx=10, pady=10, sticky="ew")
+        musteri_cerceve.grid(row=1, column=1, padx=10, pady=10, sticky="ew")
         musteri_cerceve.grid_columnconfigure(0, weight=1)
         self.yeni_siparis_musteri_entry = ctk.CTkEntry(musteri_cerceve, placeholder_text="Muhtelif (Seçim zorunlu değil)")
         self.yeni_siparis_musteri_entry.configure(state="disabled")
         self.yeni_siparis_musteri_entry.grid(row=0, column=0, sticky="ew")
         ctk.CTkButton(musteri_cerceve, text="...", width=40, command=lambda: self.cari_sec_penceresi_ac(win)).grid(row=0, column=1, padx=(5,0))
 
-        ctk.CTkLabel(win, text="Ürün Niteliği:").grid(row=1, column=0, padx=10, pady=10, sticky="w")
-        self.yeni_siparis_nitelik_entry = ctk.CTkEntry(win, placeholder_text="Örn: 8mm Temperli Şeffaf Cam")
-        self.yeni_siparis_nitelik_entry.grid(row=1, column=1, padx=10, pady=10, sticky="ew")
+        ctk.CTkLabel(win, text="Firmanın Müşterisi:").grid(row=2, column=0, padx=10, pady=10, sticky="w")
+        self.temper_firma_musterisi_entry = ctk.CTkEntry(win)
+        self.temper_firma_musterisi_entry.grid(row=2, column=1, padx=10, pady=10, sticky="ew")
 
-        ctk.CTkLabel(win, text="Miktar (m²):").grid(row=2, column=0, padx=10, pady=10, sticky="w")
+        ctk.CTkLabel(win, text="Ürün Niteliği:").grid(row=3, column=0, padx=10, pady=10, sticky="w")
+        self.yeni_siparis_nitelik_entry = ctk.CTkEntry(win, placeholder_text="Örn: 8mm Temperli Şeffaf Cam")
+        self.yeni_siparis_nitelik_entry.grid(row=3, column=1, padx=10, pady=10, sticky="ew")
+
+        ctk.CTkLabel(win, text="Miktar (m²):").grid(row=4, column=0, padx=10, pady=10, sticky="w")
         self.yeni_siparis_miktar_entry = ctk.CTkEntry(win)
-        self.yeni_siparis_miktar_entry.grid(row=2, column=1, padx=10, pady=10, sticky="ew")
+        self.yeni_siparis_miktar_entry.grid(row=4, column=1, padx=10, pady=10, sticky="ew")
+
+        ctk.CTkLabel(win, text="Fiyat:").grid(row=5, column=0, padx=10, pady=10, sticky="w")
+        self.temper_fiyat_entry = ctk.CTkEntry(win)
+        self.temper_fiyat_entry.grid(row=5, column=1, padx=10, pady=10, sticky="ew")
 
         def kaydet():
-            nitelik = self.yeni_siparis_nitelik_entry.get(); miktar_str = self.yeni_siparis_miktar_entry.get()
-            if not all([nitelik, miktar_str]): return messagebox.showerror("Hata", "Ürün Niteliği ve Miktar alanları doldurulmalıdır.", parent=win)
-            try: miktar = float(miktar_str.replace(',', '.'))
-            except ValueError: return messagebox.showerror("Hata", "Miktar sayısal olmalıdır.", parent=win)
-            
-            self.db.temper_emri_ekle(self.secili_musteri_id_yeni_siparis, nitelik, miktar)
+            nitelik = self.yeni_siparis_nitelik_entry.get()
+            miktar_str = self.yeni_siparis_miktar_entry.get()
+            fiyat_str = self.temper_fiyat_entry.get()
+            tarih = self.temper_tarih_entry.get_date().strftime('%Y-%m-%d')
+            firma_must = self.temper_firma_musterisi_entry.get()
+            if not all([nitelik, miktar_str, fiyat_str]):
+                return messagebox.showerror("Hata", "Tüm alanlar doldurulmalıdır.", parent=win)
+            try:
+                miktar = float(miktar_str.replace(',', '.'))
+                fiyat = float(fiyat_str.replace(',', '.'))
+            except ValueError:
+                return messagebox.showerror("Hata", "Miktar ve Fiyat sayısal olmalıdır.", parent=win)
+
+            self.db.temper_emri_ekle(self.secili_musteri_id_yeni_siparis, firma_must, nitelik, miktar, fiyat, tarih)
+            if self.secili_musteri_id_yeni_siparis:
+                self.db.musteri_hesap_hareketi_ekle(self.secili_musteri_id_yeni_siparis, tarih, f"Temper: {nitelik}", fiyat, 0)
             messagebox.showinfo("Başarılı", "Temper siparişi başarıyla eklendi.")
             self.temper_emirlerini_goster()
+            if self.secili_musteri_id_yeni_siparis and hasattr(self.app, 'musteri_frame'):
+                self.app.musteri_frame.temper_gecmisini_goster(self.secili_musteri_id_yeni_siparis)
+                self.app.musteri_frame.hesap_hareketlerini_goster(self.secili_musteri_id_yeni_siparis)
+                self.app.musteri_frame.musterileri_goster()
             win.destroy()
 
-        ctk.CTkButton(win, text="Kaydet", command=kaydet, height=35).grid(row=3, column=1, padx=10, pady=20, sticky="e")
+        ctk.CTkButton(win, text="Kaydet", command=kaydet, height=35).grid(row=6, column=1, padx=10, pady=20, sticky="e")
         win.grid_columnconfigure(1, weight=1)
         win.transient(self); win.grab_set()
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,4 +1,8 @@
+import os
+import sys
 import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from database import Database
 
 @pytest.fixture
@@ -9,24 +13,24 @@ def db():
     db.musteri_ekle('XYZ', 'Yetkili', '2', 'x@y.com', 'adres2')
     # work orders
     db.cursor.execute(
-        "INSERT INTO is_emirleri (musteri_id, urun_niteligi, miktar_m2, durum, tarih) VALUES (?,?,?,?,?)",
-        (1, 'Glass1', 10, 'Bekliyor', '2023-01-01'))
+        "INSERT INTO is_emirleri (musteri_id, firma_musterisi, urun_niteligi, miktar_m2, fiyat, durum, tarih) VALUES (?,?,?,?,?,?,?)",
+        (1, 'CustA', 'Glass1', 10, 100, 'Bekliyor', '2023-01-01'))
     db.cursor.execute(
-        "INSERT INTO is_emirleri (musteri_id, urun_niteligi, miktar_m2, durum, tarih) VALUES (?,?,?,?,?)",
-        (2, 'Glass2', 15, 'Bekliyor', '2023-01-02'))
+        "INSERT INTO is_emirleri (musteri_id, firma_musterisi, urun_niteligi, miktar_m2, fiyat, durum, tarih) VALUES (?,?,?,?,?,?,?)",
+        (2, 'CustB', 'Glass2', 15, 150, 'Bekliyor', '2023-01-02'))
     db.cursor.execute(
-        "INSERT INTO is_emirleri (musteri_id, urun_niteligi, miktar_m2, durum, tarih) VALUES (?,?,?,?,?)",
-        (1, 'Special', 5, 'Bekliyor', '2023-01-02'))
+        "INSERT INTO is_emirleri (musteri_id, firma_musterisi, urun_niteligi, miktar_m2, fiyat, durum, tarih) VALUES (?,?,?,?,?,?,?)",
+        (1, 'CustC', 'Special', 5, 50, 'Bekliyor', '2023-01-02'))
     # temper orders
     db.cursor.execute(
-        "INSERT INTO temper_emirleri (musteri_id, urun_niteligi, miktar_m2, durum, tarih) VALUES (?,?,?,?,?)",
-        (1, 'TemGlass1', 10, 'Bekliyor', '2023-01-01'))
+        "INSERT INTO temper_emirleri (musteri_id, firma_musterisi, urun_niteligi, miktar_m2, fiyat, durum, tarih) VALUES (?,?,?,?,?,?,?)",
+        (1, 'CustA', 'TemGlass1', 10, 200, 'Bekliyor', '2023-01-01'))
     db.cursor.execute(
-        "INSERT INTO temper_emirleri (musteri_id, urun_niteligi, miktar_m2, durum, tarih) VALUES (?,?,?,?,?)",
-        (2, 'TemGlass2', 15, 'Bekliyor', '2023-01-02'))
+        "INSERT INTO temper_emirleri (musteri_id, firma_musterisi, urun_niteligi, miktar_m2, fiyat, durum, tarih) VALUES (?,?,?,?,?,?,?)",
+        (2, 'CustB', 'TemGlass2', 15, 300, 'Bekliyor', '2023-01-02'))
     db.cursor.execute(
-        "INSERT INTO temper_emirleri (musteri_id, urun_niteligi, miktar_m2, durum, tarih) VALUES (?,?,?,?,?)",
-        (1, 'TemSpecial', 5, 'Bekliyor', '2023-01-02'))
+        "INSERT INTO temper_emirleri (musteri_id, firma_musterisi, urun_niteligi, miktar_m2, fiyat, durum, tarih) VALUES (?,?,?,?,?,?,?)",
+        (1, 'CustC', 'TemSpecial', 5, 100, 'Bekliyor', '2023-01-02'))
     db.conn.commit()
     return db
 


### PR DESCRIPTION
## Summary
- extend `is_emirleri` and `temper_emirleri` tables to store customer info and price
- keep backward compatibility by altering existing tables when needed
- allow passing date/price/customer fields in order creation functions
- update GUI forms for work orders and temper orders to include date, company customer and price
- adjust tests for new schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9507fe98832d8a8c4773d08b5858