### PR TITLE
Add delete buttons and actions

### DIFF
--- a/envanter/envanter_frame.py
+++ b/envanter/envanter_frame.py
@@ -49,6 +49,7 @@ class EnvanterFrame(ctk.CTkFrame):
         button_frame.pack(pady=20, padx=20, fill="x")
         ctk.CTkButton(button_frame, text="Ekle", command=self.urun_ekle).pack(side="left", expand=True, padx=5)
         ctk.CTkButton(button_frame, text="Güncelle", command=self.urun_guncelle).pack(side="left", expand=True, padx=5)
+        ctk.CTkButton(button_frame, text="Sil", command=self.urun_sil, fg_color="#E54E55", hover_color="#C4424A").pack(side="left", expand=True, padx=5)
         ctk.CTkButton(button_frame, text="Temizle", command=self.formu_temizle).pack(side="left", expand=True, padx=5)
         
         # Sağ Liste Sütunu
@@ -103,6 +104,15 @@ class EnvanterFrame(ctk.CTkFrame):
             self.db.urun_guncelle(secili, ad, tip, float(stok), birim, float(maliyet))
             messagebox.showinfo("Başarılı", "Ürün güncellendi."); self.yenile_tum_verileri()
         except ValueError: messagebox.showerror("Hata", "Stok ve maliyet sayısal olmalıdır.")
+
+    def urun_sil(self):
+        secili = self.urun_tree.focus()
+        if not secili:
+            return messagebox.showerror("Hata", "Silmek için bir ürün seçin.")
+        if messagebox.askyesno("Onay", "Seçili ürünü silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."):
+            self.db.urun_sil(secili)
+            messagebox.showinfo("Başarılı", "Ürün silindi.")
+            self.yenile_tum_verileri()
 
     def urun_sec(self, event):
         secili = self.urun_tree.focus();

--- a/muhasebe/musteri_frame.py
+++ b/muhasebe/musteri_frame.py
@@ -37,6 +37,7 @@ class MusteriFrame(ctk.CTkFrame):
         button_frame = ctk.CTkFrame(form_frame, fg_color="transparent"); button_frame.pack(padx=10, pady=10, fill="x")
         ctk.CTkButton(button_frame, text="Ekle", command=self.musteri_ekle).pack(side="left", expand=True, padx=5)
         ctk.CTkButton(button_frame, text="Güncelle", command=self.musteri_guncelle).pack(side="left", expand=True, padx=5)
+        ctk.CTkButton(button_frame, text="Sil", command=self.musteri_sil, fg_color="#E54E55", hover_color="#C4424A").pack(side="left", expand=True, padx=5)
         ctk.CTkButton(button_frame, text="Temizle", command=self.formu_temizle).pack(side="left", expand=True, padx=5)
 
         list_frame = ctk.CTkFrame(top_frame); list_frame.grid(row=0, column=1, padx=(10, 0), pady=10, sticky="nsew")
@@ -106,6 +107,14 @@ class MusteriFrame(ctk.CTkFrame):
         if not firma_adi: return messagebox.showerror("Hata", "Firma Adı alanı zorunludur.")
         self.db.musteri_guncelle(self.selected_musteri_id, firma_adi, self.yetkili_entry.get(), self.tel_entry.get(), self.email_entry.get(), self.adres_entry.get("1.0", "end-1c"))
         messagebox.showinfo("Başarılı", "Müşteri bilgileri güncellendi."); self.yenile_ve_entegre_et()
+
+    def musteri_sil(self):
+        if not self.selected_musteri_id:
+            return messagebox.showerror("Hata", "Silmek için bir müşteri seçin.")
+        if messagebox.askyesno("Onay", "Seçili müşteriyi silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."):
+            self.db.musteri_sil(self.selected_musteri_id)
+            messagebox.showinfo("Başarılı", "Müşteri silindi.")
+            self.yenile_ve_entegre_et()
 
     def musteri_sec(self, event=None):
         selected_item = self.musteri_tree.focus();

--- a/muhasebe/sabit_gider_frame.py
+++ b/muhasebe/sabit_gider_frame.py
@@ -72,6 +72,7 @@ class SabitGiderFrame(ctk.CTkFrame):
         self.tree.heading("Gider Adı", text="Gider Adı")
         self.tree.heading("Tutar", text="Aylık Tutar", anchor="e"); self.tree.column("Tutar", anchor="e")
         self.tree.heading("Kategori", text="Kategori")
+        ctk.CTkButton(sag_sutun, text="Seçili Gideri Sil", command=self.gider_sil, fg_color="#E54E55", hover_color="#C4424A").pack(fill="x", padx=10, pady=(0,10))
 
     def sabit_giderleri_goster(self):
         for i in self.tree.get_children(): self.tree.delete(i)
@@ -129,6 +130,16 @@ class SabitGiderFrame(ctk.CTkFrame):
         if kategori and messagebox.askyesno("Onay", f"'{secilen_kategori_ad}' kategorisini silmek istediğinizden emin misiniz?"):
             self.db.kategori_sil(kategori[0])
             messagebox.showinfo("Başarılı", "Kategori silindi.")
+            self.yenile()
+
+    def gider_sil(self):
+        secili = self.tree.focus()
+        if not secili:
+            return messagebox.showerror("Hata", "Silmek için bir gider seçin.")
+        gider_id = self.tree.item(secili)['values'][0]
+        if messagebox.askyesno("Onay", "Seçili gideri silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."):
+            self.db.sabit_gider_sil(gider_id)
+            messagebox.showinfo("Başarılı", "Sabit gider silindi.")
             self.yenile()
 
     def kategori_listesini_guncelle(self):


### PR DESCRIPTION
## Summary
- enable deleting inventory items
- allow deleting customers
- add deletion support for fixed expenses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9d57b0b4832da977514af291db54