### PR TITLE
Add stock movement UI and DB retrieval

### DIFF
--- a/database.py
+++ b/database.py
@@ -150,6 +150,19 @@ class Database:
         tarih = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         self.cursor.execute("INSERT INTO stok_hareketleri (urun_id, tarih, hareket_tipi, miktar, fatura_id, aciklama) VALUES (?, ?, ?, ?, ?, ?)", (urun_id, tarih, hareket_tipi, miktar, fatura_id, aciklama)); self.conn.commit()
 
+    def stok_hareketlerini_getir(self, urun_id=None):
+        query = (
+            "SELECT sh.id, sh.tarih, e.urun_adi, sh.hareket_tipi, sh.miktar, sh.aciklama "
+            "FROM stok_hareketleri sh JOIN envanter e ON sh.urun_id = e.id"
+        )
+        params = []
+        if urun_id is not None:
+            query += " WHERE sh.urun_id = ?"
+            params.append(urun_id)
+        query += " ORDER BY sh.tarih DESC, sh.id DESC"
+        self.cursor.execute(query, tuple(params))
+        return self.cursor.fetchall()
+
     # --- MÜŞTERİ (CARİ) ---
     def musteri_ekle(self, firma_adi, yetkili, telefon, email, adres):
         try:

--- a/envanter/__init__.py
+++ b/envanter/__init__.py
@@ -1,0 +1,2 @@
+from .envanter_frame import EnvanterFrame
+from .stok_hareket_frame import StokHareketFrame

--- a/envanter/stok_hareket_frame.py
+++ b/envanter/stok_hareket_frame.py
@@ -1,0 +1,47 @@
+import customtkinter as ctk
+from tkinter import ttk
+from database import Database
+
+class StokHareketFrame(ctk.CTkFrame):
+    def __init__(self, parent, app):
+        super().__init__(parent, fg_color="transparent")
+        self.app = app
+        self.db = Database()
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(0, weight=1)
+        self._build_ui()
+        self.stok_hareketlerini_goster()
+
+    def _build_ui(self):
+        container = ctk.CTkFrame(self)
+        container.grid(row=0, column=0, padx=10, pady=10, sticky="nsew")
+        container.grid_rowconfigure(0, weight=1)
+        container.grid_columnconfigure(0, weight=1)
+
+        style = ttk.Style()
+        style.configure("Treeview", background="#2a2d2e", foreground="white",
+                        fieldbackground="#343638", borderwidth=0)
+        style.map('Treeview', background=[('selected', '#22559b')])
+
+        self.tree = ttk.Treeview(container, columns=("ID", "Tarih", "Ürün", "Tip", "Miktar", "Açıklama"), show="headings")
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb = ttk.Scrollbar(container, orient="vertical", command=self.tree.yview)
+        vsb.grid(row=0, column=1, sticky="ns")
+        self.tree.configure(yscrollcommand=vsb.set)
+
+        self.tree.heading("ID", text="ID")
+        self.tree.column("ID", width=40)
+        self.tree.heading("Tarih", text="Tarih")
+        self.tree.column("Tarih", width=140)
+        self.tree.heading("Ürün", text="Ürün")
+        self.tree.heading("Tip", text="Hareket Tipi")
+        self.tree.column("Tip", width=90)
+        self.tree.heading("Miktar", text="Miktar")
+        self.tree.column("Miktar", width=80, anchor="e")
+        self.tree.heading("Açıklama", text="Açıklama")
+
+    def stok_hareketlerini_goster(self, urun_id=None):
+        for i in self.tree.get_children():
+            self.tree.delete(i)
+        for hareket in self.db.stok_hareketlerini_getir(urun_id):
+            self.tree.insert("", "end", values=hareket)

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from muhasebe.rapor_frame import RaporFrame
 from muhasebe.sabit_gider_frame import SabitGiderFrame
 from faturalar.fatura_frame import FaturaFrame
 from envanter.envanter_frame import EnvanterFrame
+from envanter.stok_hareket_frame import StokHareketFrame
 from personel.personel_frame import PersonelFrame
 from uretim.uretim_frame import UretimFrame
 from temper.temper_frame import TemperFrame
@@ -50,6 +51,7 @@ class App(ctk.CTk):
         self.tab_view.add("İş Emirleri") 
         self.tab_view.add("Temper Siparişleri")
         self.tab_view.add("Envanter")
+        self.tab_view.add("Stok Hareketleri")
         self.tab_view.add("Personel")
         self.tab_view.add("Faturalar")
        
@@ -77,6 +79,10 @@ class App(ctk.CTk):
         # Envanter Sekmesi
         self.envanter_frame = EnvanterFrame(self.tab_view.tab("Envanter"), self)
         self.envanter_frame.pack(expand=True, fill="both")
+
+        # Stok Hareketleri Sekmesi
+        self.stok_hareket_frame = StokHareketFrame(self.tab_view.tab("Stok Hareketleri"), self)
+        self.stok_hareket_frame.pack(expand=True, fill="both")
 
         # Personel Sekmesi
         self.personel_frame = PersonelFrame(self.tab_view.tab("Personel"), self)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -11,6 +11,22 @@ def db():
     # add sample customers
     db.musteri_ekle('ABC', 'Yetkili', '1', 'a@b.com', 'adres')
     db.musteri_ekle('XYZ', 'Yetkili', '2', 'x@y.com', 'adres2')
+    # inventory items
+    u1 = db.urun_ekle('GlassA', 'Hammadde', 100, 'Adet', 10)
+    u2 = db.urun_ekle('GlassB', 'Hammadde', 50, 'Adet', 20)
+    # stock movements
+    db.cursor.execute(
+        "INSERT INTO stok_hareketleri (urun_id, tarih, hareket_tipi, miktar, fatura_id, aciklama) VALUES (?,?,?,?,?,?)",
+        (u1, '2023-01-02 09:00:00', 'Giriş', 10, None, '')
+    )
+    db.cursor.execute(
+        "INSERT INTO stok_hareketleri (urun_id, tarih, hareket_tipi, miktar, fatura_id, aciklama) VALUES (?,?,?,?,?,?)",
+        (u2, '2023-01-02 10:00:00', 'Giriş', 5, None, '')
+    )
+    db.cursor.execute(
+        "INSERT INTO stok_hareketleri (urun_id, tarih, hareket_tipi, miktar, fatura_id, aciklama) VALUES (?,?,?,?,?,?)",
+        (u1, '2023-01-03 11:00:00', 'Çıkış', 2, None, '')
+    )
     # work orders
     db.cursor.execute(
         "INSERT INTO is_emirleri (musteri_id, firma_musterisi, urun_niteligi, miktar_m2, fiyat, durum, tarih) VALUES (?,?,?,?,?,?,?)",
@@ -49,3 +65,11 @@ def test_temper_emirlerini_getir_sorted(db):
     assert _is_sorted_by_date_id(results)
     search_results = db.temper_emirlerini_getir('ABC')
     assert _is_sorted_by_date_id(search_results)
+
+def test_stok_hareketlerini_getir(db):
+    rows = db.stok_hareketlerini_getir()
+    assert _is_sorted_by_date_id(rows)
+    # filter by product
+    first_product_id = db.urunleri_getir()[0][0]
+    filtered = db.stok_hareketlerini_getir(first_product_id)
+    assert all(r[2] == 'GlassA' for r in filtered)


### PR DESCRIPTION
## Summary
- support fetching stock movement history from database
- show stock movements in new Stok Hareketleri tab
- export StokHareketFrame in envanter package
- test stock movement retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9d6bdc94832d98d43bae774ca4ee