### PR TITLE
Refresh related views on order update

### DIFF
--- a/database.py
+++ b/database.py
@@ -274,6 +274,9 @@ class Database:
         self.cursor.execute(query, params)
         return self.cursor.fetchall()
     def is_emri_durum_guncelle(self, is_emri_id, yeni_durum): self.cursor.execute("UPDATE is_emirleri SET durum = ? WHERE id = ?", (yeni_durum, is_emri_id)); self.conn.commit()
+    def is_emri_getir_by_id(self, is_emri_id):
+        self.cursor.execute("SELECT * FROM is_emirleri WHERE id = ?", (is_emri_id,))
+        return self.cursor.fetchone()
     def is_emirlerini_getir_by_musteri_id(self, musteri_id): self.cursor.execute("SELECT id, tarih, urun_niteligi, miktar_m2, durum FROM is_emirleri WHERE musteri_id = ? ORDER BY tarih DESC, id DESC", (musteri_id,)); return self.cursor.fetchall()
 
     # --- TEMPER SİPARİŞ FONKSİYONLARI ---
@@ -298,6 +301,9 @@ class Database:
         self.cursor.execute(query, params)
         return self.cursor.fetchall()
     def temper_emri_durum_guncelle(self, temper_emri_id, yeni_durum): self.cursor.execute("UPDATE temper_emirleri SET durum = ? WHERE id = ?", (yeni_durum, temper_emri_id)); self.conn.commit()
+    def temper_emri_getir_by_id(self, temper_emri_id):
+        self.cursor.execute("SELECT * FROM temper_emirleri WHERE id = ?", (temper_emri_id,))
+        return self.cursor.fetchone()
     def temper_emirlerini_getir_by_musteri_id(self, musteri_id): self.cursor.execute("SELECT id, tarih, urun_niteligi, miktar_m2, durum FROM temper_emirleri WHERE musteri_id = ? ORDER BY tarih DESC, id DESC", (musteri_id,)); return self.cursor.fetchall()
     
     # --- RAPORLAMA ---

--- a/event_bus.py
+++ b/event_bus.py
@@ -1,0 +1,10 @@
+class EventBus:
+    def __init__(self):
+        self._subscribers = {}
+
+    def subscribe(self, event_name, callback):
+        self._subscribers.setdefault(event_name, []).append(callback)
+
+    def publish(self, event_name, *args, **kwargs):
+        for callback in self._subscribers.get(event_name, []):
+            callback(*args, **kwargs)

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from envanter.envanter_frame import EnvanterFrame
 from personel.personel_frame import PersonelFrame
 from uretim.uretim_frame import UretimFrame
 from temper.temper_frame import TemperFrame
+from event_bus import EventBus
 
 # Gerekli kütüphanelerin kontrolü
 try:
@@ -28,6 +29,9 @@ class App(ctk.CTk):
         super().__init__()
         self.title("Doğuş ERP Sistemi")
         self.geometry("1440x820")
+
+        # Global event bus for cross-module notifications
+        self.event_bus = EventBus()
         
         # Ana Pencere Grid Yapılandırması (Başlık için üstte küçük bir alan, altta ana alan)
         self.grid_rowconfigure(0, weight=0) # Başlık satırı

--- a/muhasebe/musteri_frame.py
+++ b/muhasebe/musteri_frame.py
@@ -9,9 +9,13 @@ class MusteriFrame(ctk.CTkFrame):
         self.app = app
         self.db = Database()
         self.selected_musteri_id = None
-        
+
         self.arayuzu_kur()
         self.musterileri_goster()
+
+        if hasattr(self.app, 'event_bus'):
+            self.app.event_bus.subscribe('is_emri_guncellendi', self._on_is_emri_guncellendi)
+            self.app.event_bus.subscribe('temper_emri_guncellendi', self._on_temper_emri_guncellendi)
 
     def arayuzu_kur(self):
         self.grid_columnconfigure(0, weight=1)
@@ -152,3 +156,13 @@ class MusteriFrame(ctk.CTkFrame):
         self.musterileri_goster(); self.formu_temizle()
         if hasattr(self.app, 'fatura_frame'): self.app.fatura_frame.verileri_yukle()
         if hasattr(self.app, 'finans_frame'): self.app.finans_frame.yenile()
+
+    def _on_is_emri_guncellendi(self, musteri_id):
+        if str(musteri_id) == str(self.selected_musteri_id):
+            self.is_gecmisini_goster(musteri_id)
+        self.musterileri_goster()
+
+    def _on_temper_emri_guncellendi(self, musteri_id):
+        if str(musteri_id) == str(self.selected_musteri_id):
+            self.temper_gecmisini_goster(musteri_id)
+        self.musterileri_goster()

--- a/temper/temper_frame.py
+++ b/temper/temper_frame.py
@@ -165,3 +165,6 @@ class TemperFrame(ctk.CTkFrame):
     def durumu_guncelle(self, siparis_id, yeni_durum):
         self.db.temper_emri_durum_guncelle(siparis_id, yeni_durum)
         self.temper_emirlerini_goster(self.arama_entry.get())
+        emri = self.db.temper_emri_getir_by_id(siparis_id)
+        if emri and hasattr(self.app, 'event_bus'):
+            self.app.event_bus.publish('temper_emri_guncellendi', emri[1])

--- a/uretim/uretim_frame.py
+++ b/uretim/uretim_frame.py
@@ -170,3 +170,6 @@ class UretimFrame(ctk.CTkFrame):
     def durumu_guncelle(self, is_emri_id, yeni_durum):
         self.db.is_emri_durum_guncelle(is_emri_id, yeni_durum)
         self.is_emirlerini_goster(self.arama_entry.get())
+        emri = self.db.is_emri_getir_by_id(is_emri_id)
+        if emri and hasattr(self.app, 'event_bus'):
+            self.app.event_bus.publish('is_emri_guncellendi', emri[1])


### PR DESCRIPTION
## Summary
- create a simple `EventBus` for broadcasting events
- use the bus in `App` and subscribe from `MusteriFrame`
- publish events from work order and temper order updates
- add helpers in `Database` to fetch orders by id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9d7c212c832d9363feda54d0c8a6