### PR TITLE
Make customer selection optional

### DIFF
--- a/temper/temper_frame.py
+++ b/temper/temper_frame.py
@@ -84,6 +84,8 @@ class TemperFrame(ctk.CTkFrame):
         musteri_cerceve.grid(row=1, column=1, padx=10, pady=10, sticky="ew")
         musteri_cerceve.grid_columnconfigure(0, weight=1)
         self.yeni_siparis_musteri_entry = ctk.CTkEntry(musteri_cerceve, placeholder_text="Muhtelif (Seçim zorunlu değil)")
+        # show a default value so it's clear a customer selection isn't required
+        self.yeni_siparis_musteri_entry.insert(0, "Muhtelif")
         self.yeni_siparis_musteri_entry.configure(state="disabled")
         self.yeni_siparis_musteri_entry.grid(row=0, column=0, sticky="ew")
         ctk.CTkButton(musteri_cerceve, text="...", width=40, command=lambda: self.cari_sec_penceresi_ac(win)).grid(row=0, column=1, padx=(5,0))

--- a/uretim/uretim_frame.py
+++ b/uretim/uretim_frame.py
@@ -89,6 +89,8 @@ class UretimFrame(ctk.CTkFrame):
         musteri_cerceve.grid(row=1, column=1, padx=10, pady=10, sticky="ew")
         musteri_cerceve.grid_columnconfigure(0, weight=1)
         self.yeni_is_emri_musteri_entry = ctk.CTkEntry(musteri_cerceve, placeholder_text="Muhtelif (Seçim zorunlu değil)")
+        # show a default value so it's clear a customer selection isn't required
+        self.yeni_is_emri_musteri_entry.insert(0, "Muhtelif")
         self.yeni_is_emri_musteri_entry.configure(state="disabled")
         self.yeni_is_emri_musteri_entry.grid(row=0, column=0, sticky="ew")
         ctk.CTkButton(musteri_cerceve, text="...", width=40, command=lambda: self.cari_sec_penceresi_ac(win)).grid(row=0, column=1, padx=(5,0))


### PR DESCRIPTION
## Summary
- show default text of `Muhtelif` in Work Orders and Temper Orders to make the customer field obviously optional

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685aa37f8050832d9030da09a58a0255