### PR TITLE
Ensure invoices see new inventory items

### DIFF
--- a/envanter/envanter_frame.py
+++ b/envanter/envanter_frame.py
@@ -131,3 +131,5 @@ class EnvanterFrame(ctk.CTkFrame):
         self.urunleri_goster(); self.formu_temizle()
         if hasattr(self.app, 'uretim_frame'): self.app.uretim_frame.verileri_yukle()
         if hasattr(self.app, 'fatura_frame'): self.app.fatura_frame.verileri_yukle()
+        if hasattr(self.app, 'event_bus'):
+            self.app.event_bus.publish('envanter_guncellendi')

--- a/faturalar/fatura_frame.py
+++ b/faturalar/fatura_frame.py
@@ -12,6 +12,8 @@ class FaturaFrame(ctk.CTkFrame):
         self.grid_columnconfigure(0, weight=1); self.grid_rowconfigure(0, weight=1)
         self.arayuzu_kur()
         self.verileri_yukle()
+        if hasattr(self.app, 'event_bus'):
+            self.app.event_bus.subscribe('envanter_guncellendi', self.verileri_yukle)
 
     def arayuzu_kur(self):
         main_frame = ctk.CTkFrame(self); main_frame.grid(row=0, column=0, sticky="nsew", padx=10, pady=10)


### PR DESCRIPTION
## Summary
- publish a new `envanter_guncellendi` event when inventory is refreshed
- subscribe the invoice frame to update products whenever this event fires

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aaf776f5c832dbb63fecda5dc7f94