### PR TITLE
Improve Treeview header contrast

### DIFF
--- a/envanter/envanter_frame.py
+++ b/envanter/envanter_frame.py
@@ -62,7 +62,16 @@ class EnvanterFrame(ctk.CTkFrame):
         self.arama_entry.pack(padx=10, pady=5, fill="x")
         self.arama_entry.bind("<KeyRelease>", lambda e: self.urunleri_goster())
 
-        style = ttk.Style(); style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0); style.map('Treeview', background=[('selected', '#22559b')]); style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style = ttk.Style()
+        style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
+        style.map("Treeview", background=[("selected", "#22559b")])
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
         self.urun_tree = ttk.Treeview(list_container, columns=("ID", "Ad", "Tip", "Stok", "Birim", "Maliyet"), show="headings")
         self.urun_tree.pack(expand=True, fill="both", padx=10, pady=10)
         self.urun_tree.heading("ID", text="ID"); self.urun_tree.column("ID", width=40)

--- a/envanter/stok_hareket_frame.py
+++ b/envanter/stok_hareket_frame.py
@@ -22,7 +22,13 @@ class StokHareketFrame(ctk.CTkFrame):
         style.configure("Treeview", background="#2a2d2e", foreground="white",
                         fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
-        style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
 
         self.tree = ttk.Treeview(container, columns=("ID", "Tarih", "Ürün", "Tip", "Miktar", "Açıklama"), show="headings")
         self.tree.grid(row=0, column=0, sticky="nsew")

--- a/faturalar/fatura_frame.py
+++ b/faturalar/fatura_frame.py
@@ -51,7 +51,16 @@ class FaturaFrame(ctk.CTkFrame):
         # Fatura Kalemleri Listesi
         kalemler_frame = ctk.CTkFrame(main_frame); kalemler_frame.grid(row=1, column=0, columnspan=2, padx=10, pady=10, sticky="nsew")
         kalemler_frame.grid_rowconfigure(0, weight=1); kalemler_frame.grid_columnconfigure(0, weight=1)
-        style = ttk.Style(); style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0); style.map('Treeview', background=[('selected', '#22559b')]); style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style = ttk.Style()
+        style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
+        style.map("Treeview", background=[("selected", "#22559b")])
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
         self.tree = ttk.Treeview(kalemler_frame, columns=("Ürün Adı", "Miktar / m²", "Birim Fiyatı", "Toplam"), show="headings"); self.tree.grid(row=0, column=0, sticky="nsew")
         for col in self.tree['columns']: self.tree.heading(col, text=col)
         

--- a/main.py
+++ b/main.py
@@ -34,7 +34,13 @@ class App(ctk.CTk):
 
         # Global Treeview header style
         style = ttk.Style()
-        style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
 
         # Global event bus for cross-module notifications
         self.event_bus = EventBus()

--- a/muhasebe/finans_frame.py
+++ b/muhasebe/finans_frame.py
@@ -87,7 +87,16 @@ class FinansFrame(ctk.CTkFrame):
             tree_frame = ctk.CTkFrame(self.history_tab, fg_color='transparent')
             tree_frame.grid(row=1, column=0, sticky='nsew', padx=5, pady=5)
             tree_frame.grid_rowconfigure(0, weight=1); tree_frame.grid_columnconfigure(0, weight=1)
-            style = ttk.Style(); style.configure('Treeview', background='#2a2d2e', foreground='white', fieldbackground='#343638', borderwidth=0); style.map('Treeview', background=[('selected', '#22559b')]); style.configure('Treeview.Heading', background='#333333', foreground='white', relief='flat')
+            style = ttk.Style()
+            style.configure('Treeview', background='#2a2d2e', foreground='white', fieldbackground='#343638', borderwidth=0)
+            style.map('Treeview', background=[('selected', '#22559b')])
+            style.configure(
+                'Treeview.Heading',
+                background='#1E1E2F',
+                foreground='#FFFFFF',
+                relief='flat',
+                font=('Helvetica', 10, 'bold'),
+            )
             self.tree = ttk.Treeview(tree_frame, show='headings')
             self.tree.grid(row=0, column=0, sticky='nsew')
             vsb = ttk.Scrollbar(tree_frame, orient='vertical', command=self.tree.yview); vsb.grid(row=0, column=1, sticky='ns')

--- a/muhasebe/kasa_banka_frame.py
+++ b/muhasebe/kasa_banka_frame.py
@@ -43,7 +43,13 @@ class KasaBankaFrame(ctk.CTkFrame):
         style = ttk.Style()
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
-        style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
         
         self.tree = ttk.Treeview(
             list_frame,

--- a/muhasebe/musteri_frame.py
+++ b/muhasebe/musteri_frame.py
@@ -54,7 +54,13 @@ class MusteriFrame(ctk.CTkFrame):
         
         style = ttk.Style(); style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
-        style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
         self.musteri_tree = ttk.Treeview(list_frame, columns=("ID", "Firma Adı", "Yetkili", "Bakiye"), show="headings"); self.musteri_tree.pack(expand=True, fill="both", padx=10, pady=10)
         # "ID" sütun başlığını kullanıcı arayüzünde "No" olarak göster
         self.musteri_tree.heading("ID", text="No"); self.musteri_tree.column("ID", width=50)

--- a/muhasebe/rapor_frame.py
+++ b/muhasebe/rapor_frame.py
@@ -89,7 +89,15 @@ class RaporFrame(ctk.CTkFrame):
         sag_frame.grid(row=0, column=1, padx=(5,0), sticky="nsew")
         sag_frame.grid_rowconfigure(0, weight=1); sag_frame.grid_columnconfigure(0, weight=1)
         
-        style = ttk.Style(); style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0); style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style = ttk.Style()
+        style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
         tree = ttk.Treeview(sag_frame, columns=("Tip", "Açıklama", "Tutar"), show="headings"); tree.pack(expand=True, fill="both", padx=10, pady=10)
         tree.heading("Tip", text="Tip"); tree.column("Tip", width=120)
         tree.heading("Açıklama", text="Açıklama")

--- a/muhasebe/sabit_gider_frame.py
+++ b/muhasebe/sabit_gider_frame.py
@@ -66,7 +66,13 @@ class SabitGiderFrame(ctk.CTkFrame):
         style = ttk.Style()
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
-        style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
         self.tree = ttk.Treeview(sag_sutun, columns=("ID", "Gider Adı", "Tutar", "Kategori"), show="headings")
         self.tree.pack(expand=True, fill="both", padx=10, pady=10)
         self.tree.heading("ID", text="ID"); self.tree.column("ID", width=50)

--- a/personel/personel_frame.py
+++ b/personel/personel_frame.py
@@ -59,7 +59,13 @@ class PersonelFrame(ctk.CTkFrame):
         style = ttk.Style()
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
-        style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
         self.tree = ttk.Treeview(list_frame, columns=("ID", "Ad Soyad", "Pozisyon", "Maaş"), show="headings")
         self.tree.pack(expand=True, fill="both", padx=10, pady=10)
         for col in self.tree['columns']: self.tree.heading(col, text=col)

--- a/temper/temper_frame.py
+++ b/temper/temper_frame.py
@@ -39,7 +39,13 @@ class TemperFrame(ctk.CTkFrame):
         style = ttk.Style()
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
-        style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
         
         self.tree = ttk.Treeview(liste_frame, columns=("ID", "Tarih", "Firma Adı", "Ürün Niteliği", "Miktar", "Durum"), show="headings")
         self.tree.pack(side="left", expand=True, fill="both")

--- a/uretim/uretim_frame.py
+++ b/uretim/uretim_frame.py
@@ -39,7 +39,13 @@ class UretimFrame(ctk.CTkFrame):
         style = ttk.Style()
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
-        style.configure("Treeview.Heading", background="#333333", foreground="white", relief="flat")
+        style.configure(
+            "Treeview.Heading",
+            background="#1E1E2F",
+            foreground="#FFFFFF",
+            relief="flat",
+            font=("Helvetica", 10, "bold"),
+        )
         
         self.tree = ttk.Treeview(liste_frame, columns=("ID", "Tarih", "Firma Adı", "Ürün Niteliği", "Miktar", "Durum"), show="headings")
         self.tree.pack(side="left", expand=True, fill="both")


### PR DESCRIPTION
## Summary
- tweak global `Treeview.Heading` style
- apply new heading style across all modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d133d9d44832da23ba207c2d4f9cb