### PR TITLE
Fix ttk headers not showing style

### DIFF
--- a/envanter/envanter_frame.py
+++ b/envanter/envanter_frame.py
@@ -63,6 +63,7 @@ class EnvanterFrame(ctk.CTkFrame):
         self.arama_entry.bind("<KeyRelease>", lambda e: self.urunleri_goster())
 
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map("Treeview", background=[("selected", "#22559b")])
         style.configure(

--- a/envanter/stok_hareket_frame.py
+++ b/envanter/stok_hareket_frame.py
@@ -19,6 +19,7 @@ class StokHareketFrame(ctk.CTkFrame):
         container.grid_columnconfigure(0, weight=1)
 
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure("Treeview", background="#2a2d2e", foreground="white",
                         fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])

--- a/faturalar/fatura_frame.py
+++ b/faturalar/fatura_frame.py
@@ -52,6 +52,7 @@ class FaturaFrame(ctk.CTkFrame):
         kalemler_frame = ctk.CTkFrame(main_frame); kalemler_frame.grid(row=1, column=0, columnspan=2, padx=10, pady=10, sticky="nsew")
         kalemler_frame.grid_rowconfigure(0, weight=1); kalemler_frame.grid_columnconfigure(0, weight=1)
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map("Treeview", background=[("selected", "#22559b")])
         style.configure(

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ class App(ctk.CTk):
 
         # Global Treeview header style
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure(
             "Treeview.Heading",
             background="#1E1E2F",

--- a/muhasebe/finans_frame.py
+++ b/muhasebe/finans_frame.py
@@ -88,6 +88,7 @@ class FinansFrame(ctk.CTkFrame):
             tree_frame.grid(row=1, column=0, sticky='nsew', padx=5, pady=5)
             tree_frame.grid_rowconfigure(0, weight=1); tree_frame.grid_columnconfigure(0, weight=1)
             style = ttk.Style()
+            style.theme_use('clam')
             style.configure('Treeview', background='#2a2d2e', foreground='white', fieldbackground='#343638', borderwidth=0)
             style.map('Treeview', background=[('selected', '#22559b')])
             style.configure(

--- a/muhasebe/kasa_banka_frame.py
+++ b/muhasebe/kasa_banka_frame.py
@@ -41,6 +41,7 @@ class KasaBankaFrame(ctk.CTkFrame):
         list_frame.grid_columnconfigure(0, weight=1)
 
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
         style.configure(

--- a/muhasebe/musteri_frame.py
+++ b/muhasebe/musteri_frame.py
@@ -52,7 +52,7 @@ class MusteriFrame(ctk.CTkFrame):
         self.arama_entry = ctk.CTkEntry(list_frame, placeholder_text="Firma ara..."); self.arama_entry.pack(fill="x", padx=10, pady=5)
         self.arama_entry.bind("<KeyRelease>", self.arama_yap)
         
-        style = ttk.Style(); style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
+        style = ttk.Style(); style.theme_use("clam"); style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
         style.configure(
             "Treeview.Heading",

--- a/muhasebe/rapor_frame.py
+++ b/muhasebe/rapor_frame.py
@@ -90,6 +90,7 @@ class RaporFrame(ctk.CTkFrame):
         sag_frame.grid_rowconfigure(0, weight=1); sag_frame.grid_columnconfigure(0, weight=1)
         
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.configure(
             "Treeview.Heading",

--- a/muhasebe/sabit_gider_frame.py
+++ b/muhasebe/sabit_gider_frame.py
@@ -64,6 +64,7 @@ class SabitGiderFrame(ctk.CTkFrame):
 
         # --- SABİT GİDERLER LİSTESİ ---
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
         style.configure(

--- a/personel/personel_frame.py
+++ b/personel/personel_frame.py
@@ -57,6 +57,7 @@ class PersonelFrame(ctk.CTkFrame):
         list_frame.grid_columnconfigure(0, weight=1)
 
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
         style.configure(

--- a/temper/temper_frame.py
+++ b/temper/temper_frame.py
@@ -37,6 +37,7 @@ class TemperFrame(ctk.CTkFrame):
         liste_frame.grid_columnconfigure(0, weight=1)
 
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
         style.configure(

--- a/uretim/uretim_frame.py
+++ b/uretim/uretim_frame.py
@@ -37,6 +37,7 @@ class UretimFrame(ctk.CTkFrame):
         liste_frame.grid_columnconfigure(0, weight=1)
 
         style = ttk.Style()
+        style.theme_use("clam")
         style.configure("Treeview", background="#2a2d2e", foreground="white", fieldbackground="#343638", borderwidth=0)
         style.map('Treeview', background=[('selected', '#22559b')])
         style.configure(


### PR DESCRIPTION
## Summary
- enable the `clam` theme so custom Treeview header styling works
- configure Treeview styles in every frame using `theme_use("clam")`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d16010428832d899588c54ce36146