### PR TITLE
Improve glass list popup details and auto-fill

### DIFF
--- a/database.py
+++ b/database.py
@@ -289,7 +289,11 @@ class Database:
         return self.cursor.fetchall()
     def is_emri_durum_guncelle(self, is_emri_id, yeni_durum): self.cursor.execute("UPDATE is_emirleri SET durum = ? WHERE id = ?", (yeni_durum, is_emri_id)); self.conn.commit()
     def is_emri_getir_by_id(self, is_emri_id):
-        self.cursor.execute("SELECT * FROM is_emirleri WHERE id = ?", (is_emri_id,))
+        self.cursor.execute(
+            "SELECT id, musteri_id, firma_musterisi, urun_niteligi, miktar_m2, fiyat, durum, tarih "
+            "FROM is_emirleri WHERE id = ?",
+            (is_emri_id,),
+        )
         return self.cursor.fetchone()
     def is_emirlerini_getir_by_musteri_id(self, musteri_id): self.cursor.execute("SELECT id, tarih, urun_niteligi, miktar_m2, durum FROM is_emirleri WHERE musteri_id = ? ORDER BY tarih DESC, id DESC", (musteri_id,)); return self.cursor.fetchall()
 

--- a/muhasebe/musteri_frame.py
+++ b/muhasebe/musteri_frame.py
@@ -219,6 +219,7 @@ class MusteriFrame(ctk.CTkFrame):
             if musteri:
                 musteri_adi = musteri[1]
         firma_musterisi = is_emri[2] or ""
+        aciklama = is_emri[3] or ""
         toplam_m2 = sum((en * boy) / 10000 for en, boy, *_ in liste)
 
         win = ctk.CTkToplevel(self)
@@ -230,6 +231,8 @@ class MusteriFrame(ctk.CTkFrame):
         ctk.CTkLabel(info, text=f"Cari: {musteri_adi or 'Muhtelif'}").pack(anchor="w")
         if firma_musterisi:
             ctk.CTkLabel(info, text=f"Firmanın Müşterisi: {firma_musterisi}").pack(anchor="w")
+        if aciklama:
+            ctk.CTkLabel(info, text=f"Açıklama: {aciklama}").pack(anchor="w")
         ctk.CTkLabel(info, text=f"Toplam Cam Sayısı: {len(liste)}").pack(anchor="w")
         ctk.CTkLabel(info, text=f"Toplam m²: {toplam_m2:.2f}").pack(anchor="w")
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -92,3 +92,9 @@ def test_cam_listesi_ekle_ve_getir(db):
     db.cam_listesi_ekle(is_id, 1000, 2000, 2.0, 'P1')
     rows = db.cam_listesini_getir(is_id)
     assert rows == [(1000, 2000, 2.0, 'P1')]
+
+def test_is_emri_getir_by_id_order(db):
+    is_id = db.is_emri_ekle(1, 'ClientZ', 'Desc', 5, 50, '2023-01-05')
+    row = db.is_emri_getir_by_id(is_id)
+    assert row[2] == 'ClientZ'
+    assert row[3] == 'Desc'

--- a/uretim/uretim_frame.py
+++ b/uretim/uretim_frame.py
@@ -188,6 +188,7 @@ class UretimFrame(ctk.CTkFrame):
 
                 def kaydet_liste():
                     self.cam_listesi_temp = []
+                    toplam = 0
                     for i in range(adet):
                         try:
                             en = float(en_entries[i].get())
@@ -197,6 +198,9 @@ class UretimFrame(ctk.CTkFrame):
                             continue
                         poz = poz_entries[i].get()
                         self.cam_listesi_temp.append((en, boy, m2, poz))
+                        toplam += m2
+                    self.yeni_is_emri_miktar_entry.delete(0, 'end')
+                    self.yeni_is_emri_miktar_entry.insert(0, f"{toplam:.2f}")
                     p.destroy()
 
                 ctk.CTkButton(p, text="Kaydet", command=kaydet_liste).pack(pady=10)


### PR DESCRIPTION
## Summary
- show columns explicitly when fetching job by id
- display both `Firmanın Müşterisi` and `Açıklama` in the glass list popup
- auto-fill job quantity when glass list is entered
- test column order for `is_emri_getir_by_id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d1d967ee4832da888e7cedd55e386