### PR TITLE
Handle database connection errors

### DIFF
--- a/database.py
+++ b/database.py
@@ -19,9 +19,15 @@ def get_db_connection():
 
 class Database:
     def __init__(self, db_name="erp_database.db"):
+        """Veritabanı bağlantısını başlatır ve tabloları oluşturur."""
         self.conn = get_db_connection()
+
         if self.conn is None:
-            return
+            # Eğer bağlantı kurulamadıysa, bir hata fırlat ve programın devam etmesini engelle.
+            raise ConnectionError(
+                "Veritabanı bağlantısı kurulamadı. Lütfen sunucu ve ağ ayarlarını kontrol edin."
+            )
+
         self.cursor = self.conn.cursor()
         self.tablolari_olustur()
 

--- a/main.py
+++ b/main.py
@@ -119,5 +119,15 @@ class App(ctk.CTk):
 
 
 if __name__ == "__main__":
-    app = App()
-    app.mainloop()
+    try:
+        app = App()
+        app.mainloop()
+    except ConnectionError as e:
+        # Yukarıda fırlattığımız hatayı burada yakalıyoruz.
+        # Kullanıcıya bir hata penceresi göster.
+        import tkinter as tk
+        from tkinter import messagebox
+
+        root = tk.Tk()
+        root.withdraw()  # Ana pencereyi gizle
+        messagebox.showerror("Bağlantı Hatası", str(e))


### PR DESCRIPTION
## Summary
- raise `ConnectionError` if the database connection cannot be created
- show a Tk error dialog when a connection error occurs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_686cbe1ed81c832db399745dd782ffaf