### PR TITLE
Unify customers and suppliers with Cariler table

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import sys
 from muhasebe.finans_frame import FinansFrame
 from muhasebe.kasa_banka_frame import KasaBankaFrame
 from muhasebe.musteri_frame import MusteriFrame
+from muhasebe.tedarikci_frame import TedarikciFrame
 from muhasebe.rapor_frame import RaporFrame
 from muhasebe.sabit_gider_frame import SabitGiderFrame
 from faturalar.fatura_frame import FaturaFrame
@@ -79,10 +80,16 @@ class App(ctk.CTk):
         # Muhasebe Sekmesi
         self.muhasebe_tab_view = ctk.CTkTabview(self.tab_view.tab("Muhasebe"), corner_radius=6)
         self.muhasebe_tab_view.pack(expand=True, fill="both", padx=5, pady=5)
-        self.muhasebe_tab_view.add("Gelir/Gider"); self.muhasebe_tab_view.add("Kasa ve Banka"); self.muhasebe_tab_view.add("Müşteri Yönetimi"); self.muhasebe_tab_view.add("Sabit Giderler"); self.muhasebe_tab_view.add("Aylık Rapor")
+        self.muhasebe_tab_view.add("Gelir/Gider");
+        self.muhasebe_tab_view.add("Kasa ve Banka");
+        self.muhasebe_tab_view.add("Müşteri Yönetimi");
+        self.muhasebe_tab_view.add("Tedarikçi Yönetimi");
+        self.muhasebe_tab_view.add("Sabit Giderler");
+        self.muhasebe_tab_view.add("Aylık Rapor")
         self.finans_frame = FinansFrame(self.muhasebe_tab_view.tab("Gelir/Gider"), self); self.finans_frame.pack(expand=True, fill="both")
         self.kasa_banka_frame = KasaBankaFrame(self.muhasebe_tab_view.tab("Kasa ve Banka"), self); self.kasa_banka_frame.pack(expand=True, fill="both")
         self.musteri_frame = MusteriFrame(self.muhasebe_tab_view.tab("Müşteri Yönetimi"), self); self.musteri_frame.pack(expand=True, fill="both")
+        self.tedarikci_frame = TedarikciFrame(self.muhasebe_tab_view.tab("Tedarikçi Yönetimi"), self); self.tedarikci_frame.pack(expand=True, fill="both")
         self.sabit_gider_frame = SabitGiderFrame(self.muhasebe_tab_view.tab("Sabit Giderler"), self); self.sabit_gider_frame.pack(expand=True, fill="both")
         self.rapor_frame = RaporFrame(self.muhasebe_tab_view.tab("Aylık Rapor"), self); self.rapor_frame.pack(expand=True, fill="both")
 

--- a/muhasebe/tedarikci_frame.py
+++ b/muhasebe/tedarikci_frame.py
@@ -1,0 +1,70 @@
+from .musteri_frame import MusteriFrame
+
+class TedarikciFrame(MusteriFrame):
+    """Müşteri yönetim ekranının tedarikçi için uyarlanmış hali."""
+
+    def __init__(self, parent, app):
+        super().__init__(parent, app)
+        self.musterileri_goster()
+
+    # Override CRUD operations to use tedarikçi fonksiyonları
+    def musteri_ekle(self):
+        firma_adi = self.firma_adi_entry.get()
+        if not firma_adi:
+            from tkinter import messagebox
+            return messagebox.showerror("Hata", "Firma Adı alanı zorunludur.")
+        if self.db.tedarikci_ekle(
+            firma_adi,
+            self.yetkili_entry.get(),
+            self.tel_entry.get(),
+            self.email_entry.get(),
+            self.adres_entry.get("1.0", "end-1c"),
+        ):
+            from tkinter import messagebox
+            messagebox.showinfo("Başarılı", "Tedarikçi (Cari) eklendi.")
+            self.yenile_ve_entegre_et()
+        else:
+            from tkinter import messagebox
+            messagebox.showerror("Hata", "Bu firma adı zaten mevcut.")
+
+    def musterileri_goster(self, arama_terimi=""):
+        for i in self.musteri_tree.get_children():
+            self.musteri_tree.delete(i)
+        for tedarikci in self.db.tedarikcileri_getir(arama_terimi):
+            bakiye_str = f"{tedarikci[6]:.2f} ₺"
+            self.musteri_tree.insert(
+                "",
+                "end",
+                values=(tedarikci[0], tedarikci[1], tedarikci[2], bakiye_str),
+                iid=tedarikci[0],
+            )
+
+    def musteri_guncelle(self):
+        if not self.selected_musteri_id:
+            from tkinter import messagebox
+            return messagebox.showerror("Hata", "Güncellemek için bir tedarikçi seçin.")
+        firma_adi = self.firma_adi_entry.get()
+        if not firma_adi:
+            from tkinter import messagebox
+            return messagebox.showerror("Hata", "Firma Adı alanı zorunludur.")
+        self.db.tedarikci_guncelle(
+            self.selected_musteri_id,
+            firma_adi,
+            self.yetkili_entry.get(),
+            self.tel_entry.get(),
+            self.email_entry.get(),
+            self.adres_entry.get("1.0", "end-1c"),
+        )
+        from tkinter import messagebox
+        messagebox.showinfo("Başarılı", "Tedarikçi bilgileri güncellendi.")
+        self.yenile_ve_entegre_et()
+
+    def musteri_sil(self):
+        if not self.selected_musteri_id:
+            from tkinter import messagebox
+            return messagebox.showerror("Hata", "Silmek için bir tedarikçi seçin.")
+        from tkinter import messagebox
+        if messagebox.askyesno("Onay", "Seçili tedarikçiyi silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."):
+            self.db.tedarikci_sil(self.selected_musteri_id)
+            messagebox.showinfo("Başarılı", "Tedarikçi silindi.")
+            self.yenile_ve_entegre_et()


### PR DESCRIPTION
## Summary
- add a new `Cariler` table and update all foreign keys
- introduce supplier management frame using the new table
- update finance screen to load related caris by transaction type
- expose new supplier tab in main window

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_686e271f7604832d9541cee13426b06d