### PR TITLE
Align finance tables with new schema

### DIFF
--- a/muhasebe/finans_frame.py
+++ b/muhasebe/finans_frame.py
@@ -178,16 +178,6 @@ class FinansFrame(ctk.CTkFrame):
         )
 
         if basarili:
-            # Eğer işlem belirli bir cari (müşteri/tedarikçi) ile ilişkiliyse
-            # cari hesap ekstresine de hareketi ekle
-            if secilen_cari_id is not None:
-                self.db.musteri_hesap_hareketi_ekle(
-                    secilen_cari_id,
-                    tarih,
-                    aciklama,
-                    borc,
-                    alacak,
-                )
             messagebox.showinfo("Başarılı", "Finansal hareket başarıyla kaydedildi.")
             self.formu_temizle()
             self.liste_yenile()

--- a/muhasebe/musteri_frame.py
+++ b/muhasebe/musteri_frame.py
@@ -170,7 +170,7 @@ class MusteriFrame(ctk.CTkFrame):
 
     def hesap_hareketlerini_goster(self, musteri_id):
         for i in self.hesap_tree.get_children(): self.hesap_tree.delete(i)
-        for h in self.db.musteri_hesap_hareketlerini_getir(musteri_id):
+        for h in self.db.cari_hareketlerini_getir(musteri_id):
             borc = f"{h[4]:.2f} ₺" if h[4] else ""; alacak = f"{h[5]:.2f} ₺" if h[5] else ""
             bakiye = f"{h[6]:.2f} ₺"; self.hesap_tree.insert("", "end", values=(h[2], h[3], borc, alacak, bakiye))
             
@@ -278,7 +278,7 @@ class MusteriFrame(ctk.CTkFrame):
             return messagebox.showerror("Hata", "Önce bir müşteri seçin.")
 
         musteri = self.db.musteri_getir_by_id(self.selected_musteri_id)
-        hareketler = self.db.musteri_hesap_hareketlerini_getir(self.selected_musteri_id)
+        hareketler = self.db.cari_hareketlerini_getir(self.selected_musteri_id)
         html = self._ekstre_html_olustur(musteri, hareketler)
 
         fd, html_path = tempfile.mkstemp(suffix='.html')
@@ -348,7 +348,7 @@ class MusteriFrame(ctk.CTkFrame):
                              Paragraph(f"Telefon: {musteri[3]}", styles['Normal']),
                              Spacer(1,12)]
                     data = [["Tarih","Açıklama","Borç","Alacak","Bakiye"]]
-                    for h in self.db.musteri_hesap_hareketlerini_getir(musteri[0]):
+                    for h in self.db.cari_hareketlerini_getir(musteri[0]):
                         data.append([h[2], h[3],
                                      f"{h[4]:.2f}" if h[4] else '',
                                      f"{h[5]:.2f}" if h[5] else '',

--- a/muhasebe/rapor_frame.py
+++ b/muhasebe/rapor_frame.py
@@ -106,10 +106,12 @@ class RaporFrame(ctk.CTkFrame):
 
         # Hareketleri listele
         hareketler = self.db.finansal_hareketleri_getir()
-        aylik_hareketler = [h for h in hareketler if datetime.datetime.strptime(h[1], '%Y-%m-%d').month == ay and datetime.datetime.strptime(h[1], '%Y-%m-%d').year == yil]
+        aylik_hareketler = [h for h in hareketler if datetime.datetime.strptime(h[0], '%Y-%m-%d').month == ay and datetime.datetime.strptime(h[0], '%Y-%m-%d').year == yil]
         for h in aylik_hareketler:
-            if h[3] > 0: tree.insert("", "end", values=("Gelir", h[2], f"{h[3]:.2f} ₺"), tags=('gelir',))
-            if h[4] > 0: tree.insert("", "end", values=("Değişken Gider", h[2], f"{h[4]:.2f} ₺"), tags=('gider',))
+            if h[2] > 0:
+                tree.insert("", "end", values=("Gelir", h[1], f"{h[2]:.2f} ₺"), tags=('gelir',))
+            if h[3] > 0:
+                tree.insert("", "end", values=("Değişken Gider", h[1], f"{h[3]:.2f} ₺"), tags=('gider',))
         
         # Sabit giderleri listele
         tree.insert("", "end", values=("", "--- Sabit Giderler ---", ""), tags=('baslik',))

--- a/temper/temper_frame.py
+++ b/temper/temper_frame.py
@@ -129,7 +129,7 @@ class TemperFrame(ctk.CTkFrame):
 
             self.db.temper_emri_ekle(self.secili_musteri_id_yeni_siparis, firma_must, nitelik, miktar, fiyat, tarih)
             if self.secili_musteri_id_yeni_siparis:
-                self.db.musteri_hesap_hareketi_ekle(self.secili_musteri_id_yeni_siparis, tarih, f"Temper: {nitelik}", fiyat, 0)
+                self.db.cari_hareket_ekle(self.secili_musteri_id_yeni_siparis, tarih, f"Temper: {nitelik}", fiyat, 0, "Gelir")
             messagebox.showinfo("Başarılı", "Temper siparişi başarıyla eklendi.")
             self.temper_emirlerini_goster()
             if self.secili_musteri_id_yeni_siparis and hasattr(self.app, 'musteri_frame'):

--- a/uretim/uretim_frame.py
+++ b/uretim/uretim_frame.py
@@ -259,7 +259,7 @@ class UretimFrame(ctk.CTkFrame):
                 shutil.copy(self.yuklenen_liste_path, dest)
                 self.db.is_emri_liste_dosyasi_guncelle(is_id, dest)
             if self.secili_musteri_id_yeni_is_emri:
-                self.db.musteri_hesap_hareketi_ekle(self.secili_musteri_id_yeni_is_emri, tarih, f"İş Emri: {nitelik}", fiyat, 0)
+                self.db.cari_hareket_ekle(self.secili_musteri_id_yeni_is_emri, tarih, f"İş Emri: {nitelik}", fiyat, 0, "Gelir")
             messagebox.showinfo("Başarılı", "İş emri başarıyla eklendi.")
             self.is_emirlerini_goster()
             if self.secili_musteri_id_yeni_is_emri and hasattr(self.app, 'musteri_frame'):


### PR DESCRIPTION
## Summary
- implement `cariler` and new `finansal_hareketler` schema
- soft-delete cariler, filter active records
- convert monetary values to `Decimal` in finance functions
- rename and refactor cari movement helpers
- update UI modules for new database API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_686e7fb79d90832d902e38e2d7579cfc