### PR TITLE
Fix account statement refresh after new transaction

### DIFF
--- a/muhasebe/finans_frame.py
+++ b/muhasebe/finans_frame.py
@@ -179,8 +179,8 @@ class FinansFrame(ctk.CTkFrame):
 
         if basarili:
             messagebox.showinfo("Başarılı", "Finansal hareket başarıyla kaydedildi.")
-            self.formu_temizle()
             self.liste_yenile()
+            self.formu_temizle()
         else:
             messagebox.showerror("Hata", "Kayıt sırasında bir sorun oluştu.")
         


### PR DESCRIPTION
## Summary
- ensure account statement refresh runs before clearing selected customer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_686f5c9a7544832d89637ee96718eba6