### PR TITLE
Implement running balance display

### DIFF
--- a/database.py
+++ b/database.py
@@ -544,7 +544,7 @@ class Database:
                 SELECT tarih, aciklama, borc, alacak, tip
                 FROM finansal_hareketler
                 WHERE cari_id = %s AND aktif_mi = TRUE
-                ORDER BY tarih DESC, id DESC
+                ORDER BY tarih ASC, id ASC
                 """
                 )
                 cursor.execute(sql, (cari_id,))
@@ -554,7 +554,7 @@ class Database:
                 SELECT tarih, aciklama, borc, alacak, tip
                 FROM finansal_hareketler
                 WHERE aktif_mi = TRUE
-                ORDER BY tarih DESC, id DESC
+                ORDER BY tarih ASC, id ASC
                 """
                 )
                 cursor.execute(sql)

--- a/muhasebe/musteri_frame.py
+++ b/muhasebe/musteri_frame.py
@@ -169,13 +169,17 @@ class MusteriFrame(ctk.CTkFrame):
             self.ekstre_button.configure(state="normal")
 
     def hesap_hareketlerini_goster(self, musteri_id):
-        for i in self.hesap_tree.get_children(): self.hesap_tree.delete(i)
-        for h in self.db.cari_hareketlerini_getir(musteri_id):
-            borc = f"{h[4]:.2f} ₺" if h[4] else ""
-            alacak = f"{h[5]:.2f} ₺" if h[5] else ""
-            sayisal_bakiye = float(h[6] or 0.0)
-            bakiye = f"{sayisal_bakiye:.2f} ₺"
-            self.hesap_tree.insert("", "end", values=(h[2], h[3], borc, alacak, bakiye))
+        self.hesap_tree.delete(*self.hesap_tree.get_children())
+        hareketler = self.db.finansal_hareketleri_getir(musteri_id)
+        calisan_bakiye = 0.0
+        for h in hareketler:
+            borc = float(h[2] or 0.0)
+            alacak = float(h[3] or 0.0)
+            calisan_bakiye += borc - alacak
+            borc_str = f"{borc:.2f} ₺"
+            alacak_str = f"{alacak:.2f} ₺"
+            bakiye_str = f"{calisan_bakiye:.2f} ₺"
+            self.hesap_tree.insert("", "end", values=(h[0], h[1], borc_str, alacak_str, bakiye_str))
             
     def is_gecmisini_goster(self, musteri_id):
         for i in self.is_emri_tree.get_children(): self.is_emri_tree.delete(i)


### PR DESCRIPTION
## Summary
- show running balances for selected customers/suppliers
- sort financial transactions chronologically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_686f76008c60832da55eba882bdc0914